### PR TITLE
Implement dispensary availability route

### DIFF
--- a/server/src/data/dispensaries.ts
+++ b/server/src/data/dispensaries.ts
@@ -1,0 +1,47 @@
+export interface StrainStock {
+  id: string;
+  name: string;
+  stock: number;
+  price: number;
+}
+
+export interface DeliveryInfo {
+  available: boolean;
+  baseCost: number;
+}
+
+export interface Dispensary {
+  id: string;
+  name: string;
+  strains: StrainStock[];
+  delivery: DeliveryInfo;
+}
+
+const dispensaries: Dispensary[] = [
+  {
+    id: '1',
+    name: 'Tel Aviv Dispensary',
+    strains: [
+      { id: 'strain1', name: 'Erez', stock: 10, price: 50 },
+      { id: 'strain2', name: 'Avidekel', stock: 5, price: 60 }
+    ],
+    delivery: {
+      available: true,
+      baseCost: 20
+    }
+  },
+  {
+    id: '2',
+    name: 'Jerusalem Dispensary',
+    strains: [
+      { id: 'strain1', name: 'Erez', stock: 0, price: 55 },
+      { id: 'strain3', name: 'Tikun Olam', stock: 15, price: 45 }
+    ],
+    delivery: {
+      available: false,
+      baseCost: 0
+    }
+  }
+];
+
+export default dispensaries;

--- a/server/src/dispensaries.test.ts
+++ b/server/src/dispensaries.test.ts
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import express from 'express';
+import dispensaryRouter from './routes/dispensaries';
+
+describe('GET /dispensaries/:id/availability', () => {
+  const app = express();
+  app.use('/dispensaries', dispensaryRouter);
+
+  it('should return strain availability with delivery info', async () => {
+    const response = await request(app).get('/dispensaries/1/availability');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('dispensaryId', '1');
+    expect(response.body).toHaveProperty('strains');
+    expect(response.body).toHaveProperty('delivery');
+  });
+
+  it('should return 404 for unknown dispensary', async () => {
+    const response = await request(app).get('/dispensaries/999/availability');
+    expect(response.status).toBe(404);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import dispensaryRouter from './routes/dispensaries';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -6,6 +7,8 @@ const port = process.env.PORT || 3000;
 app.get('/', (_req, res) => {
   res.send('Hello from Express');
 });
+
+app.use('/dispensaries', dispensaryRouter);
 
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);

--- a/server/src/routes/dispensaries.ts
+++ b/server/src/routes/dispensaries.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import dispensaries from '../data/dispensaries';
+
+const router = express.Router();
+
+router.get(
+  '/:id/availability',
+  ((req: express.Request, res: express.Response) => {
+    const { id } = req.params;
+    const dispensary = dispensaries.find(d => d.id === id);
+
+    if (!dispensary) {
+      return res.status(404).json({ message: 'Dispensary not found' });
+    }
+
+    const response = {
+      dispensaryId: dispensary.id,
+      strains: dispensary.strains,
+      delivery: {
+        available: dispensary.delivery.available,
+        estimatedCost: dispensary.delivery.baseCost
+      }
+    };
+
+    res.json(response);
+  }) as express.RequestHandler
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- add placeholder dispensaries data
- add `/dispensaries/:id/availability` route
- expose new router in server
- test dispensary availability endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684749d46fa48327a953d59cbc30130b