### PR TITLE
Add MCP middleware and compliance-aware chat route

### DIFF
--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -1,15 +1,32 @@
 import request from 'supertest';
-import express from 'express';
+import { app } from './index';
 
 
 describe('GET /', () => {
   it('should return greeting', async () => {
-    const app = express();
-    app.get('/', (_req: express.Request, res: express.Response) => {
-      res.send('Hello from Express');
-    });
-
     const response = await request(app).get('/');
     expect(response.text).toBe('Hello from Express');
+  });
+});
+
+describe('POST /chat', () => {
+  it('blocks requests from illegal regions', async () => {
+    const response = await request(app)
+      .post('/chat')
+      .set('x-country', 'XX')
+      .send({ message: 'hello' });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('allows requests from legal regions and echoes language', async () => {
+    const response = await request(app)
+      .post('/chat')
+      .set('x-country', 'IL')
+      .set('Accept-Language', 'he')
+      .send({ message: 'hello' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.reply).toContain('he');
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,12 +1,29 @@
 import express from 'express';
+import { mcp } from './middleware/mcp';
 
-const app = express();
+export const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
 
 app.get('/', (_req, res) => {
   res.send('Hello from Express');
 });
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
+app.post('/chat', mcp, (req, res) => {
+  if (!req.mcp?.compliance.isLegal) {
+    res.status(403).json({
+      error: 'Cannabis-related content is not permitted in your region.',
+    });
+    return;
+  }
+
+  const msg = req.body.message || '';
+  res.json({ reply: `Echo (${req.mcp?.language}): ${msg}` });
 });
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}

--- a/server/src/middleware/mcp.ts
+++ b/server/src/middleware/mcp.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface MCPInfo {
+  ip: string;
+  country: string;
+  language: string;
+  compliance: {
+    isLegal: boolean;
+  };
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    mcp?: MCPInfo;
+  }
+}
+
+const LEGAL_COUNTRIES = ['IL', 'CA', 'US-CO'];
+
+export function mcp(req: Request, _res: Response, next: NextFunction) {
+  const languageHeader = req.headers['accept-language'];
+  const language = Array.isArray(languageHeader)
+    ? languageHeader[0]
+    : (languageHeader || 'en').split(',')[0];
+
+  const country =
+    (req.headers['x-country'] as string | undefined) || 'unknown';
+
+  const isLegal = LEGAL_COUNTRIES.includes(country);
+
+  req.mcp = {
+    ip: req.ip || '',
+    country,
+    language,
+    compliance: { isLegal },
+  };
+
+  next();
+}


### PR DESCRIPTION
## Summary
- add Model Context Protocol middleware to enrich requests
- add compliance-aware `/chat` route that uses the MCP info
- export the Express app for tests and update tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684749d5a45483279d291d90605ef1c4