### PR TITLE
Implement basic review API

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,12 +1,21 @@
 import express from 'express';
+import reviewsRouter from './routes/reviews';
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.use('/reviews', reviewsRouter);
 
 app.get('/', (_req, res) => {
   res.send('Hello from Express');
 });
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+export default app;

--- a/server/src/models/reviewModel.ts
+++ b/server/src/models/reviewModel.ts
@@ -1,0 +1,54 @@
+export interface Review {
+  id: number;
+  strainId: string;
+  userId: string;
+  rating: number;
+  text: string;
+  upvotes: number;
+  downvotes: number;
+  flagged: boolean;
+}
+
+let reviews: Review[] = [];
+let nextId = 1;
+
+function moderate(text: string): boolean {
+  const banned = ['badword', 'offensive'];
+  const regex = new RegExp(banned.join('|'), 'i');
+  return regex.test(text);
+}
+
+export function createReview(data: Omit<Review, 'id' | 'upvotes' | 'downvotes' | 'flagged'>): Review {
+  const review: Review = {
+    id: nextId++,
+    upvotes: 0,
+    downvotes: 0,
+    flagged: moderate(data.text),
+    ...data
+  };
+  reviews.push(review);
+  return review;
+}
+
+export function updateReview(id: number, data: Partial<Omit<Review, 'id'>>): Review | undefined {
+  const review = reviews.find(r => r.id === id);
+  if (!review) return undefined;
+  if (data.text !== undefined) {
+    review.flagged = moderate(data.text);
+  }
+  Object.assign(review, data);
+  return review;
+}
+
+export function getReviewsForStrain(strainId: string): { reviews: Review[]; averageRating: number; voteCount: number } {
+  const list = reviews.filter(r => r.strainId === strainId && !r.flagged);
+  const totalRating = list.reduce((sum, r) => sum + r.rating, 0);
+  const averageRating = list.length ? totalRating / list.length : 0;
+  const voteCount = list.reduce((sum, r) => sum + r.upvotes - r.downvotes, 0);
+  return { reviews: list, averageRating, voteCount };
+}
+
+export function resetReviews() {
+  reviews = [];
+  nextId = 1;
+}

--- a/server/src/routes/reviews.test.ts
+++ b/server/src/routes/reviews.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../index';
+import { resetReviews } from '../models/reviewModel';
+
+describe('reviews routes', () => {
+  beforeEach(() => {
+    resetReviews();
+  });
+
+  it('creates a review and retrieves stats', async () => {
+    await request(app)
+      .post('/reviews')
+      .send({ strainId: 's1', userId: 'u1', rating: 4, text: 'Great!' })
+      .expect(201);
+
+    const res = await request(app).get('/reviews/strain/s1');
+    expect(res.body.reviews.length).toBe(1);
+    expect(res.body.averageRating).toBe(4);
+  });
+
+  it('updates a review', async () => {
+    const createRes = await request(app)
+      .post('/reviews')
+      .send({ strainId: 's1', userId: 'u1', rating: 3, text: 'Ok' });
+
+    await request(app)
+      .put(`/reviews/${createRes.body.id}`)
+      .send({ rating: 5 });
+
+    const res = await request(app).get('/reviews/strain/s1');
+    expect(res.body.averageRating).toBe(5);
+  });
+
+  it('filters flagged content', async () => {
+    await request(app)
+      .post('/reviews')
+      .send({ strainId: 's1', userId: 'u1', rating: 2, text: 'badword text' })
+      .expect(201);
+
+    const res = await request(app).get('/reviews/strain/s1');
+    expect(res.body.reviews.length).toBe(0);
+    expect(res.body.averageRating).toBe(0);
+  });
+});

--- a/server/src/routes/reviews.ts
+++ b/server/src/routes/reviews.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response } from 'express';
+import { createReview, updateReview, getReviewsForStrain } from '../models/reviewModel';
+
+const router = Router();
+
+router.post('/', (req: Request, res: Response) => {
+  const { strainId, userId, rating, text } = req.body;
+  if (!strainId || !userId || typeof rating !== 'number' || !text) {
+    res.status(400).json({ error: 'Missing fields' });
+    return;
+  }
+  const review = createReview({ strainId, userId, rating, text });
+  res.status(201).json(review);
+});
+
+router.put('/:id', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const review = updateReview(id, req.body);
+  if (!review) {
+    res.status(404).json({ error: 'Review not found' });
+    return;
+  }
+  res.json(review);
+});
+
+router.get('/strain/:strainId', (req: Request, res: Response) => {
+  const result = getReviewsForStrain(req.params.strainId);
+  res.json(result);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add review model with moderation and stats helpers
- create reviews router for POST, PUT, and GET
- mount the reviews router in the Express app
- provide tests for review endpoints

## Testing
- `npx jest src/index.test.ts src/routes/reviews.test.ts --runInBand --verbose`

------
https://chatgpt.com/codex/tasks/task_e_684749d26fd08327ad20fb56ff525be6