### PR TITLE
Add strain CRUD with ChatGPT and geo middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/node": "^20.11.19"
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
+import strainRoutes from './routes/strains';
+import geoFilter from './middleware/geoFilter';
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/strains', geoFilter, strainRoutes);
 
 app.get('/', (_req, res) => {
   res.send('Hello from Express');

--- a/server/src/middleware/geoFilter.ts
+++ b/server/src/middleware/geoFilter.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+
+const allowedRegions = ['US', 'CA', 'IL'];
+
+export default function geoFilter(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const regionHeader = req.headers['x-region'];
+  const region = Array.isArray(regionHeader)
+    ? regionHeader[0]
+    : regionHeader;
+
+  if (region && allowedRegions.includes(region.toUpperCase())) {
+    next();
+  } else {
+    res.status(403).send('Region not supported');
+  }
+}

--- a/server/src/models/strainStore.ts
+++ b/server/src/models/strainStore.ts
@@ -1,0 +1,38 @@
+export interface Strain {
+  id: number;
+  name: string;
+  description: string;
+  classification: string;
+}
+
+let strains: Strain[] = [];
+let nextId = 1;
+
+export function list(): Strain[] {
+  return strains;
+}
+
+export function get(id: number): Strain | undefined {
+  return strains.find((s) => s.id === id);
+}
+
+export function add(strain: Omit<Strain, 'id'>): Strain {
+  const newStrain: Strain = { id: nextId++, ...strain };
+  strains.push(newStrain);
+  return newStrain;
+}
+
+export function update(id: number, data: Omit<Strain, 'id'>): Strain | undefined {
+  const index = strains.findIndex((s) => s.id === id);
+  if (index === -1) return undefined;
+  const updated: Strain = { id, ...data };
+  strains[index] = updated;
+  return updated;
+}
+
+export function remove(id: number): boolean {
+  const index = strains.findIndex((s) => s.id === id);
+  if (index === -1) return false;
+  strains.splice(index, 1);
+  return true;
+}

--- a/server/src/routes/strains.test.ts
+++ b/server/src/routes/strains.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+import strainRoutes from './strains';
+import geoFilter from '../middleware/geoFilter';
+
+describe('Strain routes', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/strains', geoFilter, strainRoutes);
+
+  it('should perform full CRUD', async () => {
+    const postRes = await request(app)
+      .post('/strains')
+      .set('x-region', 'US')
+      .send({ name: 'Test', description: 'A test strain' });
+    expect(postRes.status).toBe(201);
+    expect(postRes.body.id).toBeDefined();
+
+    const listRes = await request(app)
+      .get('/strains')
+      .set('x-region', 'US');
+    expect(listRes.body.length).toBe(1);
+
+    const putRes = await request(app)
+      .put(`/strains/${postRes.body.id}`)
+      .set('x-region', 'US')
+      .send({ name: 'Updated', description: 'Updated desc' });
+    expect(putRes.status).toBe(200);
+    expect(putRes.body.name).toBe('Updated');
+
+    const delRes = await request(app)
+      .delete(`/strains/${postRes.body.id}`)
+      .set('x-region', 'US');
+    expect(delRes.status).toBe(204);
+
+    const getRes = await request(app)
+      .get(`/strains/${postRes.body.id}`)
+      .set('x-region', 'US');
+    expect(getRes.status).toBe(404);
+  });
+
+  it('should block unsupported regions', async () => {
+    const res = await request(app)
+      .get('/strains')
+      .set('x-region', 'FR');
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/src/routes/strains.ts
+++ b/server/src/routes/strains.ts
@@ -1,0 +1,55 @@
+import { Router } from 'express';
+import {
+  add,
+  get,
+  list,
+  remove,
+  update,
+} from '../models/strainStore';
+import { classifyStrain } from '../services/chatgpt';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json(list());
+});
+
+router.get('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const strain = get(id);
+  if (!strain) {
+    res.status(404).send('Not found');
+  } else {
+    res.json(strain);
+  }
+});
+
+router.post('/', async (req, res) => {
+  const { name, description } = req.body;
+  const classification = await classifyStrain(description || '');
+  const strain = add({ name, description, classification });
+  res.status(201).json(strain);
+});
+
+router.put('/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { name, description } = req.body;
+  const classification = await classifyStrain(description || '');
+  const strain = update(id, { name, description, classification });
+  if (!strain) {
+    res.status(404).send('Not found');
+  } else {
+    res.json(strain);
+  }
+});
+
+router.delete('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  if (remove(id)) {
+    res.status(204).send();
+  } else {
+    res.status(404).send('Not found');
+  }
+});
+
+export default router;

--- a/server/src/services/chatgpt.ts
+++ b/server/src/services/chatgpt.ts
@@ -1,0 +1,32 @@
+export async function classifyStrain(text: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return 'Unclassified';
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: `Classify this cannabis strain description: ${text}`,
+          },
+        ],
+      }),
+    });
+    if (!response.ok) {
+      return 'Unclassified';
+    }
+    const data = await response.json();
+    return data.choices[0].message.content.trim();
+  } catch {
+    return 'Unclassified';
+  }
+}


### PR DESCRIPTION
## Summary
- implement in-memory store and ChatGPT wrapper
- add geolocation middleware for regional checks
- provide CRUD routes for strains and hook to server
- create tests for new routes and middleware
- include @types/node for TypeScript

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684749d1151c832793924d02f5ba5117