### PR TITLE
Add Prisma ORM setup with models and seed data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/canna"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ server/node_modules/
 server/dist/
 package-lock.json
 server/package-lock.json
+
+# Environment variables
+.env

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -1,0 +1,9 @@
+import { config } from 'dotenv';
+import path from 'path';
+import { PrismaClient } from '@prisma/client';
+
+config({ path: path.join(__dirname, '../../.env') });
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/server/models/schema.prisma
+++ b/server/models/schema.prisma
@@ -1,0 +1,42 @@
+// Prisma schema for Canna project
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       Int      @id @default(autoincrement())
+  email    String   @unique
+  name     String?
+  reviews  Review[]
+}
+
+model Strain {
+  id      Int      @id @default(autoincrement())
+  name    String
+  thc     Float?
+  cbd     Float?
+  reviews Review[]
+}
+
+model Review {
+  id        Int      @id @default(autoincrement())
+  rating    Int
+  comment   String?
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  strain    Strain   @relation(fields: [strainId], references: [id])
+  strainId  Int
+  createdAt DateTime @default(now())
+}
+
+model Dispensary {
+  id       Int      @id @default(autoincrement())
+  name     String
+  location String?
+}

--- a/server/package.json
+++ b/server/package.json
@@ -7,14 +7,18 @@
     "build": "tsc",
     "start": "npm run build && node dist/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "jest"
+    "test": "jest",
+    "prisma": "prisma generate --schema=server/models/schema.prisma",
+    "seed": "ts-node prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "@prisma/client": "^5.13.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
@@ -27,6 +31,7 @@
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "prisma": "^5.13.0"
   }
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,0 +1,22 @@
+import prisma from '../models';
+
+async function main() {
+  const strains = [
+    { name: 'Northern Lights', thc: 18.0, cbd: 0.1 },
+    { name: 'Blue Dream', thc: 20.0, cbd: 0.1 },
+    { name: 'OG Kush', thc: 22.0, cbd: 0.2 },
+  ];
+
+  for (const data of strains) {
+    await prisma.strain.create({ data });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,16 @@
 import express from 'express';
+import prisma from '../models';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.get('/', (_req, res) => {
   res.send('Hello from Express');
+});
+
+app.get('/strains', async (_req, res) => {
+  const strains = await prisma.strain.findMany();
+  res.json(strains);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- integrate Prisma ORM
- define models in `server/models/schema.prisma`
- provide Prisma client wrapper in `server/models`
- add seed script for initial strains
- expose `/strains` endpoint using Prisma
- ignore `.env` and provide `.env.example`

## Testing
- `npm test`
- `npm run seed` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_684749cce02883278dbe26a5b5427fcc