### PR TITLE
Add JWT auth routes with middleware

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "bcrypt": "^6.0.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
@@ -27,6 +29,8 @@
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/jsonwebtoken": "^9.0.9",
+    "@types/bcrypt": "^5.0.2"
   }
 }

--- a/server/src/auth.test.ts
+++ b/server/src/auth.test.ts
@@ -1,0 +1,42 @@
+import request from 'supertest';
+import express from 'express';
+import authRouter from './routes/auth';
+import { authMiddleware } from './middleware/auth';
+
+describe('auth routes', () => {
+  it('registers and logs in a user', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/auth', authRouter);
+
+    const registerRes = await request(app)
+      .post('/auth/register')
+      .send({ username: 'test', password: 'pass' });
+    expect(registerRes.body.token).toBeDefined();
+
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ username: 'test', password: 'pass' });
+    expect(loginRes.body.token).toBeDefined();
+  });
+
+  it('protects routes', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/auth', authRouter);
+    app.post('/reviews', authMiddleware, (req, res) => {
+      res.json({ user: (req as any).user });
+    });
+
+    const register = await request(app)
+      .post('/auth/register')
+      .send({ username: 'bob', password: 'secret' });
+    const token = register.body.token;
+
+    const reviewRes = await request(app)
+      .post('/reviews')
+      .set('Authorization', `Bearer ${token}`);
+    expect(reviewRes.status).toBe(200);
+    expect(reviewRes.body.user).toBe('bob');
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,20 @@
 import express from 'express';
+import authRouter from './routes/auth';
+import { authMiddleware } from './middleware/auth';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
 app.get('/', (_req, res) => {
   res.send('Hello from Express');
+});
+
+app.use('/auth', authRouter);
+
+app.post('/reviews', authMiddleware, (req, res) => {
+  res.json({ message: `Review submitted by ${req.user}` });
 });
 
 app.listen(port, () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+export interface AuthRequest extends Request {
+  user?: string;
+}
+
+export function authMiddleware(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { username: string };
+    req.user = payload.username;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,51 @@
+import { Router, RequestHandler } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+const router = Router();
+
+interface UserStore {
+  [username: string]: string; // username -> password hash
+}
+
+const users: UserStore = {};
+const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+const registerHandler: RequestHandler = async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    res.status(400).json({ error: 'username and password required' });
+    return;
+  }
+  if (users[username]) {
+    res.status(409).json({ error: 'user exists' });
+    return;
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  users[username] = passwordHash;
+  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+};
+
+router.post('/register', registerHandler);
+
+const loginHandler: RequestHandler = async (req, res) => {
+  const { username, password } = req.body;
+  const storedHash = users[username];
+  if (!storedHash) {
+    res.status(401).json({ error: 'invalid credentials' });
+    return;
+  }
+  const match = await bcrypt.compare(password, storedHash);
+  if (!match) {
+    res.status(401).json({ error: 'invalid credentials' });
+    return;
+  }
+  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+};
+
+router.post('/login', loginHandler);
+
+export default router;


### PR DESCRIPTION
## Summary
- add `jsonwebtoken` and `bcrypt` dependencies
- implement `/auth/register` and `/auth/login` routes
- create auth middleware and wire it to sample `/reviews` route
- add tests for authentication flows

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684749d07b248327919c5b323f0225b4